### PR TITLE
Correction of mismatched Newtonsoft.Json references

### DIFF
--- a/src/CodeGenHero.DataService/CHANGELOG.md
+++ b/src/CodeGenHero.DataService/CHANGELOG.md
@@ -1,10 +1,13 @@
 ﻿## Changelog
 
+### 1.1.5
+* Updated Newtonsoft.Json package to version 13.0.1 to match the version used in the CGH Extension for VS2022
+
 ### 1.1.4
-Removed FieldType from FilterCriterion.
+* Removed FieldType from FilterCriterion.
 
 ### 1.1.3
-Swap out CGH custom logging implementation for Microsoft.Extensions.Logging implementation.
+* Swap out CGH custom logging implementation for Microsoft.Extensions.Logging implementation.
 
 ### 1.1.1
 Bug Fixes & Enhancements:

--- a/src/CodeGenHero.DataService/CodeGenHero.DataService.csproj
+++ b/src/CodeGenHero.DataService/CodeGenHero.DataService.csproj
@@ -19,7 +19,7 @@ This package should be added to projects that are the target of CodeGenHero temp
     <PackageTags>CodeGenerator CodeGen MSCTek webapi dataservice</PackageTags>
     <PackageReleaseNotes>Classes to support invoking Web API services via HttpClient.</PackageReleaseNotes>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>1.1.4</Version>
+    <Version>1.1.5</Version>
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>CodeGenHeroKey.snk</AssemblyOriginatorKeyFile>
     <PackageIcon>CGH_Logo2.png</PackageIcon>
@@ -47,7 +47,7 @@ This package should be added to projects that are the target of CodeGenHero temp
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
   </ItemGroup>
 

--- a/src/CodeGenHero.Serialization/CHANGELOG.md
+++ b/src/CodeGenHero.Serialization/CHANGELOG.md
@@ -1,5 +1,8 @@
 ﻿## Changelog
 
+### 1.0.3
+* Updated Newtonsoft.Json package to version 13.0.1 to match the version used in the CGH Extension for VS2022
+
 ### 1.0.2
 * Floating version of NewtonSoft.Json NuGet package reference.
 

--- a/src/CodeGenHero.Serialization/CodeGenHero.Serialization.csproj
+++ b/src/CodeGenHero.Serialization/CodeGenHero.Serialization.csproj
@@ -19,7 +19,7 @@ This package should be added to projects that are used to serialize and deserial
     <PackageTags>CodeGenerator CodeGen MSCTek Serialization</PackageTags>
     <PackageReleaseNotes>Classes to support serializing and deserializing files.</PackageReleaseNotes>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>CodeGenHeroKey.snk</AssemblyOriginatorKeyFile>
     <PackageIcon>CGH_Logo2.png</PackageIcon>
@@ -38,7 +38,7 @@ This package should be added to projects that are used to serialize and deserial
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="YamlDotNet" Version="8.*" />
   </ItemGroup>
 

--- a/src/CodeGenHero.Template/CHANGELOG.md
+++ b/src/CodeGenHero.Template/CHANGELOG.md
@@ -1,5 +1,8 @@
 ﻿## Changelog
 
+### 1.4.1
+* Updated Newtonsoft.Json package to version 13.0.1 to match the version used in the CGH Extension for VS2022
+
 ### 1.4.0
 * ProcessModel.cs - Namespace change to CodeGenHero.Template.Models
 

--- a/src/CodeGenHero.Template/CodeGenHero.Template.csproj
+++ b/src/CodeGenHero.Template/CodeGenHero.Template.csproj
@@ -19,7 +19,7 @@ This package should be added to projects that are the source CodeGenHero templat
     <PackageTags>CodeGenerator CodeGen MSCTek Template</PackageTags>
     <PackageReleaseNotes>Classes to support implementation of CodeGenHero templates</PackageReleaseNotes>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>CodeGenHeroKey.snk</AssemblyOriginatorKeyFile>
     <PackageIcon>CGH_Logo2.png</PackageIcon>
@@ -48,7 +48,7 @@ This package should be added to projects that are the source CodeGenHero templat
   <ItemGroup>
     <PackageReference Include="CodeGenHero.Core" Version="1.3.2" />
     <PackageReference Include="CodeGenHero.Inflector" Version="1.0.7" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Corrected mismatched Newtonsoft.Json references in the CGH NuGet packages which could cause templates dependent on Newtson.Json methods from being able to generate.